### PR TITLE
A new branch for product variations, with no extra features.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+DEV
+===
+
+* For each product added to the Cart and Order, optional product variations can
+  be stored together in the database. Variations are stored as serialized
+  dictionaries. This makes it easier to implement customized product variations
+  and makes it easier to add features, such as wishlists, comparison carts, etc.
+
 Version 0.0.14
 ==============
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -22,6 +22,7 @@ django-cbv if you're using 1.3.
     pip install django-cbv # only if using django<1.3
     pip install south
     pip install django-shop
+    pip install jsonfield
     
 .. highlight:: python
 

--- a/shop/admin/orderadmin.py
+++ b/shop/admin/orderadmin.py
@@ -25,6 +25,7 @@ class ExtraOrderPriceFieldInline(admin.TabularInline):
 
 class OrderItemInline(admin.TabularInline):
     model = OrderItem
+    fields = ('product_name', 'unit_price', 'quantity', 'line_subtotal', 'line_total')
     extra = 0
 
 #TODO: add ExtraOrderItemPriceField inline, ideas?

--- a/shop/migrations/0008_auto__add_field_cartitem_variation__add_field_cartitem_variation_hash_.py
+++ b/shop/migrations/0008_auto__add_field_cartitem_variation__add_field_cartitem_variation_hash_.py
@@ -1,0 +1,160 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'CartItem.variation'
+        db.add_column('shop_cartitem', 'variation', self.gf('jsonfield.fields.JSONField')(null=True, blank=True), keep_default=False)
+
+        # Adding field 'CartItem.variation_hash'
+        db.add_column('shop_cartitem', 'variation_hash', self.gf('django.db.models.fields.CharField')(max_length=64, null=True), keep_default=False)
+
+        # Adding field 'OrderItem.variation'
+        db.add_column('shop_orderitem', 'variation', self.gf('jsonfield.fields.JSONField')(null=True, blank=True), keep_default=False)
+
+        # Adding field 'OrderItem.variation_hash'
+        db.add_column('shop_orderitem', 'variation_hash', self.gf('django.db.models.fields.CharField')(max_length=64, null=True), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'CartItem.variation'
+        db.delete_column('shop_cartitem', 'variation')
+
+        # Deleting field 'CartItem.variation_hash'
+        db.delete_column('shop_cartitem', 'variation_hash')
+
+        # Deleting field 'OrderItem.variation'
+        db.delete_column('shop_orderitem', 'variation')
+
+        # Deleting field 'OrderItem.variation_hash'
+        db.delete_column('shop_orderitem', 'variation_hash')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'shop.cart': {
+            'Meta': {'object_name': 'Cart'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        'shop.cartitem': {
+            'Meta': {'object_name': 'CartItem'},
+            'cart': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'items'", 'to': "orm['shop.Cart']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Product']"}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {}),
+            'variation': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'variation_hash': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'})
+        },
+        'shop.extraorderitempricefield': {
+            'Meta': {'object_name': 'ExtraOrderItemPriceField'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.OrderItem']"}),
+            'value': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        },
+        'shop.extraorderpricefield': {
+            'Meta': {'object_name': 'ExtraOrderPriceField'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_shipping': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Order']"}),
+            'value': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        },
+        'shop.order': {
+            'Meta': {'object_name': 'Order'},
+            'billing_address_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'order_subtotal': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'order_total': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'shipping_address_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'shop.orderextrainfo': {
+            'Meta': {'object_name': 'OrderExtraInfo'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'extra_info'", 'to': "orm['shop.Order']"}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        'shop.orderitem': {
+            'Meta': {'object_name': 'OrderItem'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'line_subtotal': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'line_total': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'items'", 'to': "orm['shop.Order']"}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Product']", 'null': 'True', 'blank': 'True'}),
+            'product_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'product_reference': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {}),
+            'unit_price': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'variation': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'variation_hash': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'})
+        },
+        'shop.orderpayment': {
+            'Meta': {'object_name': 'OrderPayment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Order']"}),
+            'payment_method': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'transaction_id': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'shop.product': {
+            'Meta': {'object_name': 'Product'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'polymorphic_shop.product_set'", 'null': 'True', 'to': "orm['contenttypes.ContentType']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'db_index': 'True'}),
+            'unit_price': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        }
+    }
+
+    complete_apps = ['shop']

--- a/shop/models/defaults/bases.py
+++ b/shop/models/defaults/bases.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal
+from hashlib import sha1
 from distutils.version import LooseVersion
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models.aggregates import Sum
+from django.utils import simplejson as json
 from django.utils.translation import ugettext_lazy as _
 from polymorphic.polymorphic_model import PolymorphicModel
+from jsonfield.fields import JSONField
 from shop.cart.modifiers_pool import cart_modifiers_pool
 from shop.util.fields import CurrencyField
 from shop.util.loader import get_model_string
@@ -86,57 +90,32 @@ class BaseCart(models.Model):
         self.extra_price_fields = []  # List of tuples (label, value)
         self._updated_cart_items = None
 
-    def add_product(self, product, quantity=1, merge=True, queryset=None):
+    def add_product(self, product, quantity=1, variation=None):
         """
         Adds a (new) product to the cart.
 
-        The parameter `merge`, controls wheter we should merge the added
-        CartItem with another already existing sharing the same
-        product_id. This is useful when you have products with variations
-        (for example), and you don't want to have your products merge (to loose
-        their specific variations, for example).
-
-        A drawback is, that generally  setting `merge` to ``False`` for
-        products with variations can be a problem if users can buy thousands of
-        products at a time (that would mean we would create thousands of
-        CartItems as well which all have the same variation).
-
-        The parameter `queryset` can be used to override the standard queryset
-        that is being used to find the CartItem that should be merged into.
-        If you use variations, just finding the first CartItem that
-        belongs to this cart and the given product is not sufficient. You will
-        want to find the CartItem that already has the same variations that the
-        user chose for this request.
-
-        Example with merge = True:
-        >>> self.items[0] = CartItem.objects.create(..., product=MyProduct())
-        >>> self.add_product(MyProduct())
-        >>> self.items[0].quantity
-        2
-
-        Example with merge=False:
-        >>> self.items[0] = CartItem.objects.create(..., product=MyProduct())
-        >>> self.add_product(MyProduct())
-        >>> self.items[0].quantity
-        1
-        >>> self.items[1].quantity
-        1
+        The parameter `variation`, can be any kind of JSON serializable Python
+        object.
+        If a product with exactly this variation already exists, the quantity
+        is increased in the cart. Otherwise a new product is added to the cart.
         """
         from shop.models import CartItem
-        if queryset == None:
-            queryset = CartItem.objects.filter(cart=self, product=product)
-        item = queryset
-        # Let's see if we already have an Item with the same product ID
-        if item.exists() and merge:
-            cart_item = item[0]
-            cart_item.quantity = cart_item.quantity + int(quantity)
+        # Let's see if we already have an Item with the same product ID and the
+        # same variation
+        variation_hash = sha1(json.dumps(variation, cls=DjangoJSONEncoder,
+            sort_keys=True)).hexdigest() if variation else None
+        cart_item = CartItem.objects.filter(cart=self, product=product,
+                                            variation_hash=variation_hash)
+        if cart_item.exists():
+            cart_item = cart_item[0]
+            cart_item.quantity += int(quantity)
             cart_item.save()
         else:
-            cart_item = CartItem.objects.create(
-                cart=self, quantity=quantity, product=product)
+            cart_item = CartItem.objects.create(cart=self, quantity=quantity,
+                product=product, variation=variation, variation_hash=variation_hash)
             cart_item.save()
 
-        self.save()  # to get the last updated timestamp
+        self.save() # to get the last updated timestamp
         return cart_item
 
     def update_quantity(self, cart_item_id, quantity):
@@ -252,10 +231,10 @@ class BaseCartItem(models.Model):
     pointer to the actual Product being purchased :)
     """
     cart = models.ForeignKey(get_model_string('Cart'), related_name="items")
-
     quantity = models.IntegerField()
-
     product = models.ForeignKey(get_model_string('Product'))
+    variation = JSONField(null=True, blank=True)
+    variation_hash = models.CharField(max_length=64, null=True)
 
     class Meta(object):
         abstract = True
@@ -419,9 +398,13 @@ class BaseOrderItem(models.Model):
     product_name = models.CharField(max_length=255, null=True, blank=True,
             verbose_name=_('Product name'))
     product = models.ForeignKey(get_model_string('Product'),
-        verbose_name=_('Product'), null=True, blank=True, **f_kwargs)
+            verbose_name=_('Product'), null=True, blank=True, **f_kwargs)
     unit_price = CurrencyField(verbose_name=_('Unit price'))
     quantity = models.IntegerField(verbose_name=_('Quantity'))
+    variation = JSONField(null=True, blank=True,
+            verbose_name=_('Variable Object Container'))
+    variation_hash = models.CharField(max_length=64, null=True)
+
     line_subtotal = CurrencyField(verbose_name=_('Line subtotal'))
     line_total = CurrencyField(verbose_name=_('Line total'))
 

--- a/shop/models/defaults/managers.py
+++ b/shop/models/defaults/managers.py
@@ -117,6 +117,8 @@ class OrderManager(models.Manager):
             order_item.product = item.product
             order_item.unit_price = item.product.get_price()
             order_item.quantity = item.quantity
+            order_item.variation = item.variation
+            order_item.variation_hash = item.variation_hash
             order_item.line_total = item.line_total
             order_item.line_subtotal = item.line_subtotal
             order_item.save()

--- a/shop/tests/cart.py
+++ b/shop/tests/cart.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 from decimal import Decimal
+from copy import deepcopy
 from django.contrib.auth.models import User
 from django.test.testcases import TestCase
 from shop.cart.modifiers_pool import cart_modifiers_pool
@@ -33,6 +34,18 @@ class CartTestCase(TestCase):
         self.product.active = True
         self.product.unit_price = self.PRODUCT_PRICE
         self.product.save()
+
+        self.variation = {'option_groups':
+                {1L: {'description': None, 'name': u'Color', 'id': 1L,
+                      'slug': u'color', 'option': {'price': Decimal('1.25'),
+                                     'group_id': 1L, 'id': 1L, 'name': u'red'}
+                }}, 'text_options': {1L: {'description': None,
+                                                'text': 'Hello World',
+                                                'price': Decimal('.17'),
+                                                'max_length': 12L, 'id': 1L,
+                                                'name': u'label'
+                }},
+        }
 
         self.cart = Cart()
         self.cart.user = self.user
@@ -128,17 +141,37 @@ class CartTestCase(TestCase):
             self.assertEqual(self.cart.items.all()[0].quantity, 2)
             self.assertEqual(self.cart.total_quantity, 2)
 
-    def test_add_same_object_twice_no_merge(self):
+    def test_add_same_object_twice_with_variation(self):
         with SettingsOverride(SHOP_CART_MODIFIERS=[]):
             self.assertEqual(self.cart.total_quantity, 0)
-            self.cart.add_product(self.product, merge=False)
-            self.cart.add_product(self.product, merge=False)
+            variation1 = self.variation
+            variation2 = deepcopy(self.variation)
+            variation2['option_groups'][1L]['option']['name'] = 'green'
+            self.cart.add_product(self.product, variation=variation1)
+            self.cart.add_product(self.product, variation=variation2)
             self.cart.update()
             self.cart.save()
 
-            self.assertEqual(len(self.cart.items.all()), 2)
-            self.assertEqual(self.cart.items.all()[0].quantity, 1)
-            self.assertEqual(self.cart.items.all()[1].quantity, 1)
+            cart_items = self.cart.items.all()
+            self.assertEqual(len(cart_items), 2)
+            self.assertEqual(cart_items[0].quantity, 1)
+            self.assertEqual(cart_items[1].quantity, 1)
+            self.assertEqual(cart_items[0].variation['option_groups']['1']['option']['name'], 'red')
+            self.assertEqual(cart_items[1].variation['option_groups']['1']['option']['name'], 'green')
+
+    def test_add_same_object_twice_no_variation(self):
+        with SettingsOverride(SHOP_CART_MODIFIERS=[]):
+            self.assertEqual(self.cart.total_quantity, 0)
+            self.cart.add_product(self.product, variation=self.variation)
+            variation_reordered = deepcopy(self.variation) # reorders, but must deliver the same hash
+            self.cart.add_product(self.product, variation=variation_reordered)
+            self.cart.update()
+            self.cart.save()
+
+            cart_items = self.cart.items.all()
+            self.assertEqual(len(cart_items), 1)
+            self.assertEqual(cart_items[0].quantity, 2)
+            self.assertEqual(cart_items[0].variation['option_groups']['1']['option']['name'], 'red')
 
     def test_add_product_updates_last_updated(self):
         with SettingsOverride(SHOP_CART_MODIFIERS=[]):
@@ -171,18 +204,14 @@ class CartTestCase(TestCase):
             self.cart.update_quantity(self.cart.items.all()[0].id, 0)
             self.assertEqual(len(self.cart.items.all()), 0)
 
-    def test_custom_queryset_is_used_when_passed_to_method(self):
+    def test_custom_variation_is_used_when_passed_to_method(self):
         with SettingsOverride(SHOP_CART_MODIFIERS=[]):
             # first we add any product
             self.cart.add_product(self.product)
 
-            # now we try to select a CartItem that does not exist yet. This
-            # could be an item with a yet unused combination of variations.
-            qs = CartItem.objects.filter(cart=self.cart, product=self.product,
-                                         quantity=42)
-            # although we add the same product and have merge=True, there
+            # add another product with a different variation
             # should be a new CartItem being created now.
-            self.cart.add_product(self.product, queryset=qs)
+            self.cart.add_product(self.product, variation={ 'foo': 'bar' })
             self.assertEqual(len(self.cart.items.all()), 2)
 
     def test_get_updated_cart_items(self):

--- a/shop/views/product.py
+++ b/shop/views/product.py
@@ -19,3 +19,9 @@ class ProductDetailView(ShopDetailView):
         if not self.generic_template in ret:
             ret.append(self.generic_template)
         return ret
+
+    def get_variation(self):
+        """
+        Dummy function to enable seamless view mixins.
+        """
+        return {}


### PR DESCRIPTION
This pull request replaces the previous pull request named "variations".
It is based on the posting in https://groups.google.com/forum/#!topic/django-shop/dgv32D3awpQ

This patch shall not affect current implementations, except those using Cart.add_product() with the merge-flag and queryset. django-shop-simplevariations is such a candidate.

The main difference is, that you pass variations as a free-form dict to Cart.add_product(). The function then decides itself, whether it shall merge or add. This makes programming of product variations and other features such as wishlists and comparison carts much simpler.

Modules using this feature can be found here: https://github.com/jrief/django-shop-productvariations and here: https://github.com/jrief/django-shop-wishlists

Some unit tests were rewritten, and one was added.