### PR TITLE
Fix example/myshop/models/auth.py

### DIFF
--- a/example/myshop/models/auth.py
+++ b/example/myshop/models/auth.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.conf.settings import SHOP_APP_LABEL
+from django.conf import settings
 from shop.models.auth import BaseCustomer
 
 
@@ -9,7 +9,7 @@ class Customer(BaseCustomer):
     Replace `auth.models.User` with this alternative implementation.
     """
     class Meta:
-        app_label = SHOP_APP_LABEL
+        app_label = settings.SHOP_APP_LABEL
 
 # Migrate from auth_user table:
 # INSERT INTO myshop_customer (id,password,last_login,is_superuser,username,first_name,last_name,email,is_staff,is_active,date_joined) \


### PR DESCRIPTION
As per the Django docs, we should not import individual settings, but always
the settings object itself.