### PR TITLE
Pin the Django 1.8 version in the requirements

### DIFF
--- a/requirements/django18/common.txt
+++ b/requirements/django18/common.txt
@@ -1,3 +1,4 @@
+Django==1.8.7
 beautifulsoup4==4.4.0
 cmsplugin-filer==0.10.2
 django-admin-sortable2==0.6.1


### PR DESCRIPTION
Without this, we will get Django 1.9, causing the travis build to fail when it
should not.

This should fix the Travis build for 1.8.